### PR TITLE
deal with param name change for etopo datasets

### DIFF
--- a/R/rxtracto.R
+++ b/R/rxtracto.R
@@ -205,6 +205,16 @@ oldDataFrame <- out_dataframe[1, ]
 # logical variable if the latitude coordinate goes south to north
 #latSouth <- working_coords$latSouth
 
+# deal with name change of extracted param for etopo datasets
+if (grepl('etopo', attr(dataInfo, "datasetid"))) {
+  extract_param <- "depth"
+
+}else{
+  extract_param <- parameter
+
+}
+
+
 # loop over the track positions
  for (i in seq_len(length(xcoord))) {
 
@@ -320,9 +330,9 @@ oldDataFrame <- out_dataframe[1, ]
 
 
     # populate the dataframe
-     out_dataframe[i, 1] <- mean(extract[[parameter]], na.rm = TRUE)
-     out_dataframe[i, 2] <- stats::sd(extract[[parameter]], na.rm = TRUE)
-     out_dataframe[i, 3] <- length(extract[[parameter]][!is.na(extract[[parameter]])])
+     out_dataframe[i, 1] <- mean(extract[[extract_param]], na.rm = TRUE)
+     out_dataframe[i, 2] <- stats::sd(extract[[extract_param]], na.rm = TRUE)
+     out_dataframe[i, 3] <- length(extract[[extract_param]][!is.na(extract[[extract_param]])])
      if (!is.null(working_coords$tcoord1)) {
        out_dataframe[i, 4] <- requesttime
      }
@@ -335,8 +345,8 @@ oldDataFrame <- out_dataframe[1, ]
      if (!is.null(working_coords$tcoord1)) {
        out_dataframe[i, 11] <- as.character.Date(tcoord[i])
      }
-     out_dataframe[i, 12] <- stats::median(extract[[parameter]], na.rm = TRUE)
-     out_dataframe[i, 13] <- stats::mad(extract[[parameter]], na.rm = TRUE)
+     out_dataframe[i, 12] <- stats::median(extract[[extract_param]], na.rm = TRUE)
+     out_dataframe[i, 13] <- stats::mad(extract[[extract_param]], na.rm = TRUE)
 
    }
    # store last request in case next one is same


### PR DESCRIPTION
Currently using rxtracto() for ETOPO datasets doesn't work.

For example, the following code from the vignette doesn't work:

`tagData <- Marlintag38606
xpos <- tagData$lon[10]
ypos <- tagData$lat[10]
topoInfo <- rerddap::info('etopo360')
topo <- rxtracto(topoInfo, parameter = 'altitude', xcoord = xpos, ycoord = ypos, xlen = .1, ylen = .1)
str(topo)
`
The output is:

> List of 13
 $ mean altitude    : num NaN
 $ stdev altitude   : num NA
 $ n                : int 0
 $ satellite date   : logi NA
 $ requested lon min: num 206
 $ requested lon max: num 206
 $ requested lat min: num 20.4
 $ requested lat max: num 20.5
 $ requested z min  : logi NA
 $ requested z max  : logi NA
 $ requested date   : logi NA
 $ median altitude  : logi NA
 $ mad altitude     : num NA
 - attr(*, "row.names")= chr "1"
 - attr(*, "class")= chr [1:2] "list" "rxtractoTrack"

Note that the "mean altitude"s (ie depths) are all NaN. This is because data_extract_read() smartly changes the parameter name of it's return value (in variable "extract") to "depth", but rxtracto() still tries to index into this return value using "altitude" as the parameter name.

My proposed fix is to check for "etopo" dataset requests in rxtracto() and set the variable 'extract_param' appropriately (either "depth" or original parameter name) and then subsequently use 'extract_param' to index into the "extract" list returned by data_extract_read() .

rxtracto_3D() and rxtractogon() don't suffer from this problem since they return the output from data_extract_read() without making assumptions about the names of its elements.